### PR TITLE
Updated growl method to properly pass the icon path in cygwin

### DIFF
--- a/lib/autotest/growl.rb
+++ b/lib/autotest/growl.rb
@@ -90,6 +90,9 @@ module Autotest::Growl
       system %(notify-send "#{title}" "#{message}" -i #{image} -t 5000)
     when /windows|mswin|mingw|cygwin/i
       growl += '.com'
+			if(Config::CONFIG['host_os'] =~ /cygwin/i)
+				image = `cygpath -w #{image}`
+			end
       system %(#{growl} #{message.inspect} /a:"Autotest" /r:"Autotest" /n:"Autotest" /i:"#{image}" /p:#{priority} /t:"#{title}" /s:#{sticky})
     else
       raise "#{Config::CONFIG['host_os']} is not supported by autotest-growl (feel free to submit a patch)" 


### PR DESCRIPTION
growlnotify.com needs the icon paths in Windows format, since it's a Windows executable.  If we're on Cygwin using Cygwin's ruby package, paths will be in the Unix style.  I used the Cygwin "cygpath" command to convert the image path to Windows format when sending a notification.  This allows the icon to show up properly.
